### PR TITLE
Convert int64 type to Dart string

### DIFF
--- a/generator/generate.dart
+++ b/generator/generate.dart
@@ -442,9 +442,10 @@ class TlObjectArg {
       case 'int':
       case 'int32':
       case 'int53':
-      case 'int64':
       case 'long':
         return 'int';
+      case 'int64':
+        return 'String';
       case 'double':
         return 'double';
       case 'string':

--- a/lib/src/tdapi/functions/answer_callback_query.dart
+++ b/lib/src/tdapi/functions/answer_callback_query.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class AnswerCallbackQuery extends TdFunction {
-  int callbackQueryId;
+  String callbackQueryId;
   String text;
   bool showAlert;
   String url;

--- a/lib/src/tdapi/functions/answer_custom_query.dart
+++ b/lib/src/tdapi/functions/answer_custom_query.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class AnswerCustomQuery extends TdFunction {
-  int customQueryId;
+  String customQueryId;
   String data;
   dynamic extra;
 

--- a/lib/src/tdapi/functions/answer_inline_query.dart
+++ b/lib/src/tdapi/functions/answer_inline_query.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class AnswerInlineQuery extends TdFunction {
-  int inlineQueryId;
+  String inlineQueryId;
   bool isPersonal;
   List<InputInlineQueryResult> results;
   int cacheTime;

--- a/lib/src/tdapi/functions/answer_pre_checkout_query.dart
+++ b/lib/src/tdapi/functions/answer_pre_checkout_query.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class AnswerPreCheckoutQuery extends TdFunction {
-  int preCheckoutQueryId;
+  String preCheckoutQueryId;
   String errorMessage;
   dynamic extra;
 

--- a/lib/src/tdapi/functions/answer_shipping_query.dart
+++ b/lib/src/tdapi/functions/answer_shipping_query.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class AnswerShippingQuery extends TdFunction {
-  int shippingQueryId;
+  String shippingQueryId;
   List<ShippingOption> shippingOptions;
   String errorMessage;
   dynamic extra;

--- a/lib/src/tdapi/functions/change_sticker_set.dart
+++ b/lib/src/tdapi/functions/change_sticker_set.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class ChangeStickerSet extends TdFunction {
-  int setId;
+  String setId;
   bool isInstalled;
   bool isArchived;
   dynamic extra;

--- a/lib/src/tdapi/functions/delete_profile_photo.dart
+++ b/lib/src/tdapi/functions/delete_profile_photo.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class DeleteProfilePhoto extends TdFunction {
-  int profilePhotoId;
+  String profilePhotoId;
   dynamic extra;
 
   /// Deletes a profile photo. 

--- a/lib/src/tdapi/functions/discard_call.dart
+++ b/lib/src/tdapi/functions/discard_call.dart
@@ -4,7 +4,7 @@ class DiscardCall extends TdFunction {
   int callId;
   bool isDisconnected;
   int duration;
-  int connectionId;
+  String connectionId;
   dynamic extra;
 
   /// Discards a call. 

--- a/lib/src/tdapi/functions/disconnect_website.dart
+++ b/lib/src/tdapi/functions/disconnect_website.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class DisconnectWebsite extends TdFunction {
-  int websiteId;
+  String websiteId;
   dynamic extra;
 
   /// Disconnects website from the current user's Telegram account. 

--- a/lib/src/tdapi/functions/finish_file_generation.dart
+++ b/lib/src/tdapi/functions/finish_file_generation.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class FinishFileGeneration extends TdFunction {
-  int generationId;
+  String generationId;
   TdError error;
   dynamic extra;
 

--- a/lib/src/tdapi/functions/get_archived_sticker_sets.dart
+++ b/lib/src/tdapi/functions/get_archived_sticker_sets.dart
@@ -2,7 +2,7 @@ part of '../tdapi.dart';
 
 class GetArchivedStickerSets extends TdFunction {
   bool isMasks;
-  int offsetStickerSetId;
+  String offsetStickerSetId;
   int limit;
   dynamic extra;
 

--- a/lib/src/tdapi/functions/get_chat_event_log.dart
+++ b/lib/src/tdapi/functions/get_chat_event_log.dart
@@ -3,7 +3,7 @@ part of '../tdapi.dart';
 class GetChatEventLog extends TdFunction {
   int chatId;
   String query;
-  int fromEventId;
+  String fromEventId;
   int limit;
   ChatEventLogFilters filters;
   List<int> userIds;

--- a/lib/src/tdapi/functions/get_chats.dart
+++ b/lib/src/tdapi/functions/get_chats.dart
@@ -2,7 +2,7 @@ part of '../tdapi.dart';
 
 class GetChats extends TdFunction {
   ChatList chatList;
-  int offsetOrder;
+  String offsetOrder;
   int offsetChatId;
   int limit;
   dynamic extra;

--- a/lib/src/tdapi/functions/get_sticker_set.dart
+++ b/lib/src/tdapi/functions/get_sticker_set.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class GetStickerSet extends TdFunction {
-  int setId;
+  String setId;
   dynamic extra;
 
   /// Returns information about a sticker set by its identifier. 

--- a/lib/src/tdapi/functions/remove_background.dart
+++ b/lib/src/tdapi/functions/remove_background.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class RemoveBackground extends TdFunction {
-  int backgroundId;
+  String backgroundId;
   dynamic extra;
 
   /// Removes background from the list of installed backgrounds. 

--- a/lib/src/tdapi/functions/reorder_installed_sticker_sets.dart
+++ b/lib/src/tdapi/functions/reorder_installed_sticker_sets.dart
@@ -2,7 +2,7 @@ part of '../tdapi.dart';
 
 class ReorderInstalledStickerSets extends TdFunction {
   bool isMasks;
-  List<int> stickerSetIds;
+  List<String> stickerSetIds;
   dynamic extra;
 
   /// Changes the order of installed sticker sets. 

--- a/lib/src/tdapi/functions/search_secret_messages.dart
+++ b/lib/src/tdapi/functions/search_secret_messages.dart
@@ -3,7 +3,7 @@ part of '../tdapi.dart';
 class SearchSecretMessages extends TdFunction {
   int chatId;
   String query;
-  int fromSearchId;
+  String fromSearchId;
   int limit;
   SearchMessagesFilter filter;
   dynamic extra;

--- a/lib/src/tdapi/functions/send_inline_query_result_message.dart
+++ b/lib/src/tdapi/functions/send_inline_query_result_message.dart
@@ -4,7 +4,7 @@ class SendInlineQueryResultMessage extends TdFunction {
   int chatId;
   int replyToMessageId;
   SendMessageOptions options;
-  int queryId;
+  String queryId;
   String resultId;
   bool hideViaBot;
   dynamic extra;

--- a/lib/src/tdapi/functions/set_file_generation_progress.dart
+++ b/lib/src/tdapi/functions/set_file_generation_progress.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class SetFileGenerationProgress extends TdFunction {
-  int generationId;
+  String generationId;
   int expectedSize;
   int localPrefixSize;
   dynamic extra;

--- a/lib/src/tdapi/functions/set_supergroup_sticker_set.dart
+++ b/lib/src/tdapi/functions/set_supergroup_sticker_set.dart
@@ -2,7 +2,7 @@ part of '../tdapi.dart';
 
 class SetSupergroupStickerSet extends TdFunction {
   int supergroupId;
-  int stickerSetId;
+  String stickerSetId;
   dynamic extra;
 
   /// Changes the sticker set of a supergroup; requires can_change_info rights. 

--- a/lib/src/tdapi/functions/terminate_session.dart
+++ b/lib/src/tdapi/functions/terminate_session.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class TerminateSession extends TdFunction {
-  int sessionId;
+  String sessionId;
   dynamic extra;
 
   /// Terminates a session of the current user. 

--- a/lib/src/tdapi/functions/view_trending_sticker_sets.dart
+++ b/lib/src/tdapi/functions/view_trending_sticker_sets.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class ViewTrendingStickerSets extends TdFunction {
-  List<int> stickerSetIds;
+  List<String> stickerSetIds;
   dynamic extra;
 
   /// Informs the server that some trending sticker sets have been viewed by the user. 

--- a/lib/src/tdapi/functions/write_generated_file_part.dart
+++ b/lib/src/tdapi/functions/write_generated_file_part.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class WriteGeneratedFilePart extends TdFunction {
-  int generationId;
+  String generationId;
   int offset;
   String data;
   dynamic extra;

--- a/lib/src/tdapi/objects/background.dart
+++ b/lib/src/tdapi/objects/background.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class Background extends TdObject {
-  int id;
+  String id;
   bool isDefault;
   bool isDark;
   String name;

--- a/lib/src/tdapi/objects/call_connection.dart
+++ b/lib/src/tdapi/objects/call_connection.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class CallConnection extends TdObject {
-  int id;
+  String id;
   String ip;
   String ipv6;
   int port;

--- a/lib/src/tdapi/objects/chat_event.dart
+++ b/lib/src/tdapi/objects/chat_event.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class ChatEvent extends TdObject {
-  int id;
+  String id;
   int date;
   int userId;
   ChatEventAction action;

--- a/lib/src/tdapi/objects/chat_event_action.dart
+++ b/lib/src/tdapi/objects/chat_event_action.dart
@@ -641,8 +641,8 @@ class ChatEventSignMessagesToggled extends ChatEventAction {
 }
 
 class ChatEventStickerSetChanged extends ChatEventAction {
-  int oldStickerSetId;
-  int newStickerSetId;
+  String oldStickerSetId;
+  String newStickerSetId;
 
   /// The supergroup sticker set was changed. 
   /// [oldStickerSetId] Previous identifier of the chat sticker set; 0 if none . 

--- a/lib/src/tdapi/objects/chat_photo.dart
+++ b/lib/src/tdapi/objects/chat_photo.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class ChatPhoto extends TdObject {
-  int id;
+  String id;
   int addedDate;
   Minithumbnail minithumbnail;
   List<PhotoSize> sizes;

--- a/lib/src/tdapi/objects/chat_position.dart
+++ b/lib/src/tdapi/objects/chat_position.dart
@@ -2,7 +2,7 @@ part of '../tdapi.dart';
 
 class ChatPosition extends TdObject {
   ChatList list;
-  int order;
+  String order;
   bool isPinned;
   ChatSource source;
 

--- a/lib/src/tdapi/objects/connected_website.dart
+++ b/lib/src/tdapi/objects/connected_website.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class ConnectedWebsite extends TdObject {
-  int id;
+  String id;
   String domainName;
   int botUserId;
   String browser;

--- a/lib/src/tdapi/objects/found_messages.dart
+++ b/lib/src/tdapi/objects/found_messages.dart
@@ -2,7 +2,7 @@ part of '../tdapi.dart';
 
 class FoundMessages extends TdObject {
   List<Message> messages;
-  int nextFromSearchId;
+  String nextFromSearchId;
   dynamic extra;
 
   /// Contains a list of messages found by a search. 

--- a/lib/src/tdapi/objects/game.dart
+++ b/lib/src/tdapi/objects/game.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class Game extends TdObject {
-  int id;
+  String id;
   String shortName;
   String title;
   FormattedText text;

--- a/lib/src/tdapi/objects/inline_query_results.dart
+++ b/lib/src/tdapi/objects/inline_query_results.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class InlineQueryResults extends TdObject {
-  int inlineQueryId;
+  String inlineQueryId;
   String nextOffset;
   List<InlineQueryResult> results;
   String switchPmText;

--- a/lib/src/tdapi/objects/input_background.dart
+++ b/lib/src/tdapi/objects/input_background.dart
@@ -60,7 +60,7 @@ class InputBackgroundLocal extends InputBackground {
 }
 
 class InputBackgroundRemote extends InputBackground {
-  int backgroundId;
+  String backgroundId;
 
   /// A background from the server. 
   /// [backgroundId] The background identifier

--- a/lib/src/tdapi/objects/input_chat_photo.dart
+++ b/lib/src/tdapi/objects/input_chat_photo.dart
@@ -37,7 +37,7 @@ class InputChatPhoto extends TdObject {
 }
 
 class InputChatPhotoPrevious extends InputChatPhoto {
-  int chatPhotoId;
+  String chatPhotoId;
 
   /// A previously used profile photo of the current user. 
   /// [chatPhotoId] Identifier of the profile photo to reuse

--- a/lib/src/tdapi/objects/message.dart
+++ b/lib/src/tdapi/objects/message.dart
@@ -22,7 +22,7 @@ class Message extends TdObject {
   int viaBotUserId;
   String authorSignature;
   int views;
-  int mediaAlbumId;
+  String mediaAlbumId;
   String restrictionReason;
   MessageContent content;
   ReplyMarkup replyMarkup;

--- a/lib/src/tdapi/objects/message_content.dart
+++ b/lib/src/tdapi/objects/message_content.dart
@@ -1140,7 +1140,7 @@ class MessageCustomServiceAction extends MessageContent {
 
 class MessageGameScore extends MessageContent {
   int gameMessageId;
-  int gameId;
+  String gameId;
   int score;
 
   /// A new high score was achieved in a game. 

--- a/lib/src/tdapi/objects/poll.dart
+++ b/lib/src/tdapi/objects/poll.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class Poll extends TdObject {
-  int id;
+  String id;
   String question;
   List<PollOption> options;
   int totalVoterCount;

--- a/lib/src/tdapi/objects/profile_photo.dart
+++ b/lib/src/tdapi/objects/profile_photo.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class ProfilePhoto extends TdObject {
-  int id;
+  String id;
   File small;
   File big;
   bool hasAnimation;

--- a/lib/src/tdapi/objects/push_receiver_id.dart
+++ b/lib/src/tdapi/objects/push_receiver_id.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class PushReceiverId extends TdObject {
-  int id;
+  String id;
   dynamic extra;
 
   /// Contains a globally unique push receiver identifier, which can be used to identify which account has received a push notification. 

--- a/lib/src/tdapi/objects/session.dart
+++ b/lib/src/tdapi/objects/session.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class Session extends TdObject {
-  int id;
+  String id;
   bool isCurrent;
   bool isPasswordPending;
   int apiId;

--- a/lib/src/tdapi/objects/sticker.dart
+++ b/lib/src/tdapi/objects/sticker.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class Sticker extends TdObject {
-  int setId;
+  String setId;
   int width;
   int height;
   String emoji;

--- a/lib/src/tdapi/objects/sticker_set.dart
+++ b/lib/src/tdapi/objects/sticker_set.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class StickerSet extends TdObject {
-  int id;
+  String id;
   String title;
   String name;
   Thumbnail thumbnail;

--- a/lib/src/tdapi/objects/sticker_set_info.dart
+++ b/lib/src/tdapi/objects/sticker_set_info.dart
@@ -1,7 +1,7 @@
 part of '../tdapi.dart';
 
 class StickerSetInfo extends TdObject {
-  int id;
+  String id;
   String title;
   String name;
   Thumbnail thumbnail;

--- a/lib/src/tdapi/objects/supergroup_full_info.dart
+++ b/lib/src/tdapi/objects/supergroup_full_info.dart
@@ -16,7 +16,7 @@ class SupergroupFullInfo extends TdObject {
   bool canSetLocation;
   bool canViewStatistics;
   bool isAllHistoryAvailable;
-  int stickerSetId;
+  String stickerSetId;
   ChatLocation location;
   String inviteLink;
   int upgradedFromBasicGroupId;

--- a/lib/src/tdapi/objects/t_me_url_type.dart
+++ b/lib/src/tdapi/objects/t_me_url_type.dart
@@ -118,7 +118,7 @@ class TMeUrlTypeChatInvite extends TMeUrlType {
 }
 
 class TMeUrlTypeStickerSet extends TMeUrlType {
-  int stickerSetId;
+  String stickerSetId;
 
   /// A URL linking to a sticker set. 
   /// [stickerSetId] Identifier of the sticker set

--- a/lib/src/tdapi/objects/update.dart
+++ b/lib/src/tdapi/objects/update.dart
@@ -1858,7 +1858,7 @@ class UpdateFile extends Update {
 }
 
 class UpdateFileGenerationStart extends Update {
-  int generationId;
+  String generationId;
   String originalPath;
   String destinationPath;
   String conversion;
@@ -1901,7 +1901,7 @@ class UpdateFileGenerationStart extends Update {
 }
 
 class UpdateFileGenerationStop extends Update {
-  int generationId;
+  String generationId;
   dynamic extra;
 
   /// File generation is no longer needed. 
@@ -2143,7 +2143,7 @@ class UpdateStickerSet extends Update {
 
 class UpdateInstalledStickerSets extends Update {
   bool isMasks;
-  List<int> stickerSetIds;
+  List<String> stickerSetIds;
   dynamic extra;
 
   /// The list of installed sticker sets was updated. 
@@ -2155,7 +2155,7 @@ class UpdateInstalledStickerSets extends Update {
   /// Parse from a json
   UpdateInstalledStickerSets.fromJson(Map<String, dynamic> json)  {
     this.isMasks = json['is_masks'];
-    this.stickerSetIds = List<int>.from((json['sticker_set_ids'] ?? []).map((item) => item).toList());
+    this.stickerSetIds = List<String>.from((json['sticker_set_ids'] ?? []).map((item) => item).toList());
     this.extra = json['@extra'];
   }
 
@@ -2546,7 +2546,7 @@ class UpdateSuggestedActions extends Update {
 }
 
 class UpdateNewInlineQuery extends Update {
-  int id;
+  String id;
   int senderUserId;
   Location userLocation;
   String query;
@@ -2642,11 +2642,11 @@ class UpdateNewChosenInlineResult extends Update {
 }
 
 class UpdateNewCallbackQuery extends Update {
-  int id;
+  String id;
   int senderUserId;
   int chatId;
   int messageId;
-  int chatInstance;
+  String chatInstance;
   CallbackQueryPayload payload;
   dynamic extra;
 
@@ -2695,10 +2695,10 @@ class UpdateNewCallbackQuery extends Update {
 }
 
 class UpdateNewInlineCallbackQuery extends Update {
-  int id;
+  String id;
   int senderUserId;
   String inlineMessageId;
-  int chatInstance;
+  String chatInstance;
   CallbackQueryPayload payload;
   dynamic extra;
 
@@ -2743,7 +2743,7 @@ class UpdateNewInlineCallbackQuery extends Update {
 }
 
 class UpdateNewShippingQuery extends Update {
-  int id;
+  String id;
   int senderUserId;
   String invoicePayload;
   Address shippingAddress;
@@ -2786,7 +2786,7 @@ class UpdateNewShippingQuery extends Update {
 }
 
 class UpdateNewPreCheckoutQuery extends Update {
-  int id;
+  String id;
   int senderUserId;
   String currency;
   int totalAmount;
@@ -2872,7 +2872,7 @@ class UpdateNewCustomEvent extends Update {
 }
 
 class UpdateNewCustomQuery extends Update {
-  int id;
+  String id;
   String data;
   int timeout;
   dynamic extra;
@@ -2938,7 +2938,7 @@ class UpdatePoll extends Update {
 }
 
 class UpdatePollAnswer extends Update {
-  int pollId;
+  String pollId;
   int userId;
   List<int> optionIds;
   dynamic extra;


### PR DESCRIPTION
For some reason, int64 is returned as string from the Telegram server.
Adjust the generator to generate string type for int64 fields.

This fixes https://github.com/i-Naji/tdlib/issues/15.